### PR TITLE
Docs: add UAT Reviewer / Tester gate

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -17,3 +17,10 @@ Suggested scripts:
 - run format checks
 - run lint checks
 - run tests
+
+Deployment gate:
+- A deployment is not considered complete until it passes UAT review.
+- After every successful deployment, the UAT Reviewer / Tester must open the Vercel deployment URL in a browser.
+- The reviewer must verify visual alignment with the PRD, check core interactions, and confirm that data loads correctly.
+- If the deployed build fails any check, the reviewer must document the issue with clear reproduction steps and send it back for Devin to fix before the deployment is accepted.
+- Keep this gate mandatory for every future deployment.

--- a/docs/uat-reviewer.md
+++ b/docs/uat-reviewer.md
@@ -1,0 +1,28 @@
+# UAT Reviewer / Tester instructions
+
+Role
+- Validate every successful deployment before it is considered approved for release.
+
+Required actions
+1. Open the deployed Vercel URL in a browser.
+2. Check whether the screen visually matches the PRD.
+3. Test core functions such as buttons, navigation, and data loading.
+4. Report any defect back with clear notes so Devin can fix it.
+
+Review standards
+- Verify layout, spacing, hierarchy, labels, and major visual elements against the PRD.
+- Confirm loading, error, and empty states behave as expected where applicable.
+- Confirm primary actions are clickable and produce the intended behavior.
+- Confirm no obvious runtime errors block the page.
+
+Reporting format
+- Deployment URL
+- What was tested
+- What passed
+- What failed
+- Reproduction steps for any issue
+- Whether the deployment is approved or needs fixes
+
+Gate rule
+- Do not approve the deployment if the page fails visual review or the main functionality is broken.
+- If any issue is found, return it to Devin for correction before release approval.


### PR DESCRIPTION
Adds the UAT Reviewer / Tester workflow and deployment gate documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/burakkilicaslan/zenith-invest-terminal/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
