### PR TITLE
Fix live-data env toggle to accept legacy alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 # `true` in the deployment environment to resolve mapped indicators
 # from the providers below. Missing keys degrade only the affected
 # provider — the rest of the dashboard continues to serve live data.
+#
+# Supported toggle env names:
+# - ZENITH_LIVE_DATA (preferred)
+# - ZENITHLIVEDATA (legacy alias supported by the code)
 ZENITH_LIVE_DATA=
 FRED_API_KEY=
 FMP_API_KEY=

--- a/frontend/lib/live/config.ts
+++ b/frontend/lib/live/config.ts
@@ -40,15 +40,27 @@ export const PROVIDER_POLICIES: Record<string, ProviderPolicy> = {
   TCMB: { ...DEFAULT_POLICY, timeoutMs: 6_000, cacheTtlMs: 30 * 60 * 1000 },
 };
 
+const LIVE_DATA_ENV_NAMES = ["ZENITH_LIVE_DATA", "ZENITHLIVEDATA"] as const;
+
 /**
  * Live-mode toggle. Keep this a function (not a constant) so tests
- * and server restarts re-read the environment each call.
+ * and server restarts re-read the environment each call. Support both
+ * the documented `ZENITH_LIVE_DATA` key and the legacy alias without
+ * underscores so deployments keep working during migration.
  */
 export function isLiveDataEnabled(): boolean {
-  const flag = process.env.ZENITH_LIVE_DATA;
-  if (!flag) return false;
-  const normalized = flag.toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes";
+  return readBooleanEnv(LIVE_DATA_ENV_NAMES);
+}
+
+function readBooleanEnv(names: readonly string[]): boolean {
+  for (const name of names) {
+    const flag = process.env[name];
+    if (flag === undefined || flag === null) continue;
+    const normalized = flag.trim().toLowerCase();
+    if (!normalized) continue;
+    return normalized === "1" || normalized === "true" || normalized === "yes";
+  }
+  return false;
 }
 
 export interface ProviderKeyLookup {


### PR DESCRIPTION
Issue #23 root cause: the live toggle only read ZENITH_LIVE_DATA, while the deployed Vercel env was set as ZENITHLIVEDATA. This patch keeps the toggle runtime-based and accepts both names so the dashboard can leave mock mode without breaking the documented env key.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/burakkilicaslan/zenith-invest-terminal/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
