### PR TITLE
EPIC2-issue-32: US-only AI macro commentary (remove TR logic)

### DIFF
--- a/frontend/lib/live/aiSummary.ts
+++ b/frontend/lib/live/aiSummary.ts
@@ -175,55 +175,6 @@ export function deriveAiSummary(
     }
   }
 
-  // TR policy + inflation ----------------------------------------------
-  const policy = lookup.byId("tr-policy-rate");
-  const cpi = lookup.byId("tr-cpi-yoy");
-  if (policy && cpi) {
-    const realRate = policy.value - cpi.value;
-    const policyText = formatPercent(policy.value, 1);
-    const cpiText = formatPercent(cpi.value, 1);
-    const realText = formatPercent(realRate, 1);
-    if (realRate > 0) {
-      highlights.push(
-        `TCMB politika faizi ${policyText}, TÜFE ${cpiText} — reel faiz ${realText}, dezenflasyon destekleniyor.`,
-      );
-    } else {
-      risks.push(
-        `TCMB politika faizi ${policyText}, TÜFE ${cpiText} — reel faiz ${realText}, TL için risk.`,
-      );
-    }
-  } else if (policy) {
-    risks.push(
-      `TCMB politika faizi ${formatPercent(policy.value, 1)} — reel faiz izlenmeli.`,
-    );
-  } else if (cpi) {
-    risks.push(`Türkiye TÜFE ${formatPercent(cpi.value, 1)} — yüksek enflasyon sürüyor.`);
-  }
-
-  // TR reserves --------------------------------------------------------
-  const reserves = lookup.byId("tr-tcmb-reserves");
-  if (reserves) {
-    const reservesText = `${formatNumber(reserves.value, 1)} Mr$`;
-    if (reserves.trend === "up") {
-      highlights.push(
-        `TCMB rezervleri ${reservesText} seviyesinde artış eğiliminde; dış tamponlar güçleniyor.`,
-      );
-    } else if (reserves.trend === "down") {
-      risks.push(`TCMB rezervleri ${reservesText} seviyesinde geriliyor.`);
-    }
-  }
-
-  // TR CDS -------------------------------------------------------------
-  const cds = lookup.byId("tr-5y-cds");
-  if (cds) {
-    const cdsText = `${formatNumber(cds.value, 0)} bp`;
-    if (cds.trend === "down") {
-      highlights.push(`Türkiye 5Y CDS ${cdsText} ile daralıyor; risk primi iyileşiyor.`);
-    } else if (cds.trend === "up") {
-      risks.push(`Türkiye 5Y CDS ${cdsText} ile genişliyor; risk primi yükseliyor.`);
-    }
-  }
-
   // ---------- Verdict + narrative ----------
   const verdict = resolveVerdict(highlights.length, risks.length);
   const headline = HEADLINE[verdict];
@@ -297,19 +248,7 @@ function buildNarrative(
     );
   }
 
-  const policy = lookup.byId("tr-policy-rate");
-  const cpi = lookup.byId("tr-cpi-yoy");
-  const reserves = lookup.byId("tr-tcmb-reserves");
-  if (policy && cpi) {
-    const bits = [
-      `politika faizi ${formatPercent(policy.value, 1)}`,
-      `TÜFE ${formatPercent(cpi.value, 1)}`,
-    ];
-    if (reserves) {
-      bits.push(`TCMB rezervleri ${formatNumber(reserves.value, 1)} Mr$`);
-    }
-    parts.push(`Türkiye tarafında ${bits.join(", ")}.`);
-  }
+
 
   const preamble = {
     favorable:

--- a/frontend/lib/mocks/macro.ts
+++ b/frontend/lib/mocks/macro.ts
@@ -631,16 +631,13 @@ const aiSummary: MacroAiSummary = {
   verdict: "cautious",
   headline: "Seçici yatırım ortamı",
   narrative:
-    "Makro resim temkinli-pozitif: ABD tarafında dezenflasyon yavaş ilerlerken getiri eğrisi hâlâ tersine dönmüş durumda ve Fed bilançosu küçülmeye devam ediyor; buna karşın CNN Korku & Hırs Endeksi ılımlı hırs bölgesine (%58) geçti ve investors.com CAN SLIM tavsiyesi %60'a yükseldi — bu bileşim, kalite ve momentum taraflı seçici pozisyonlanmayı destekliyor. Türkiye tarafında CDS primi daralıyor, TCMB rezervleri artıyor ve dezenflasyon sürüyor, ancak politika faizindeki yatay seyir ve yüksek enflasyon reel bazda önlemli kalmayı gerektiriyor.",
+    "Makro resim temkinli-pozitif: ABD tarafında dezenflasyon yavaş ilerlerken getiri eğrisi hâlâ tersine dönmüş durumda ve Fed bilançosu küçülmeye devam ediyor; buna karşın CNN Korku & Hırs Endeksi ılımlı hırs bölgesine (%58) geçti ve investors.com CAN SLIM tavsiyesi %60'a yükseldi — bu bileşim, kalite ve momentum taraflı seçici pozisyonlanmayı destekliyor.",
   highlights: [
     "ABD yatırımcı duyarlılığı (CNN Korku & Hırs 58) ve CAN SLIM tavsiye ağırlığı (%60) 'confirmed uptrend' bölgesinde.",
-    "Türkiye 5Y CDS primi 268 bp ile çok aylık dip; dış tamponlar güçleniyor.",
-    "Türkiye dezenflasyonu sürüyor (TÜFE %38,2, yılbaşından bu yana yaklaşık 17 puan iyileşme).",
   ],
   risks: [
     "ABD 10Y–2Y eğrisi hâlâ negatif (-14 bp), resesyon sinyali canlı.",
     "VIX 17,4'e yükseldi; oynaklık trendi yukarı yönlü.",
-    "TCMB politika faizi %42,5'te sabit, reel faiz katı — erken bir indirim döngüsü TL için risk oluşturur.",
   ],
   confidence: 0.62,
   model: "mock: kural tabanlı sentez",
@@ -652,10 +649,6 @@ const aiSummary: MacroAiSummary = {
     "us-fed-bs",
     "us-fear-greed",
     "us-canslim-exposure",
-    "tr-5y-cds",
-    "tr-tcmb-reserves",
-    "tr-policy-rate",
-    "tr-cpi-yoy",
   ],
   sources: [
     SRC_FRED,
@@ -663,13 +656,10 @@ const aiSummary: MacroAiSummary = {
     SRC_CBOE,
     SRC_CNN,
     SRC_INVESTORS,
-    SRC_TCMB,
-    SRC_TURKSTAT,
-    SRC_IHS,
+    SRC_FED,
     SRC_INTERNAL,
   ],
 };
-
 export const mockMacroDashboard: MacroDashboard = {
   generatedAt: GENERATED_AT,
   source: "mock",


### PR DESCRIPTION
Removes Turkey-specific content from macro dashboard AI commentary.

- frontend/lib/live/aiSummary.ts: deriveAiSummary/buildNarrative now generate narrative/highlights/risks using US indicators only.
- frontend/lib/mocks/macro.ts: mock aiSummary narrative/highlights/risks/sources/relatedIndicators now only cover US.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/burakkilicaslan/zenith-invest-terminal/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
